### PR TITLE
com.utilities.async 1.2.2

### DIFF
--- a/Utilities.Async/Packages/com.utilities.async/package.json
+++ b/Utilities.Async/Packages/com.utilities.async/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Async",
   "description": "A set of utilities to ease the use of async methods in Unity.",
   "keywords": [],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.async#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.async/releases",
@@ -16,7 +16,7 @@
   "url": "https://github.com/StephenHodgson",
   "dependencies": {
     "com.unity.editorcoroutines": "1.0.0",
-    "com.unity.test-framework": "2.0.1-pre.18"
+    "com.unity.test-framework": "1.3.3"
   },
   "hideInEditor": true,
   "publishConfig": {

--- a/Utilities.Async/Packages/manifest.json
+++ b/Utilities.Async/Packages/manifest.json
@@ -1,9 +1,8 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.18",
-    "com.unity.ide.visualstudio": "2.0.17",
-    "com.unity.ide.vscode": "1.2.5",
-    "com.unity.test-framework": "1.1.33",
+    "com.unity.ide.rider": "3.0.21",
+    "com.unity.ide.visualstudio": "2.0.18",
+    "com.unity.test-framework": "1.3.4",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Utilities.Async/ProjectSettings/ProjectVersion.txt
+++ b/Utilities.Async/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.19f1
-m_EditorVersionWithRevision: 2021.3.19f1 (c9714fde33b6)
+m_EditorVersion: 2023.1.0b16
+m_EditorVersionWithRevision: 2023.1.0b16 (54d4e608cabd)


### PR DESCRIPTION
- Fixes #3 Rolled back unity test framework from 2.0.1-pre.18 -> 1.3.3