### PR TITLE
com.utilities.async 1.2.3

### DIFF
--- a/Utilities.Async/Packages/com.utilities.async/Runtime/Async/AwaiterExtensions.cs
+++ b/Utilities.Async/Packages/com.utilities.async/Runtime/Async/AwaiterExtensions.cs
@@ -142,8 +142,10 @@ namespace Utilities.Async
         public static SimpleCoroutineAwaiter GetAwaiter(this WaitWhile instruction)
             => GetAwaiterReturnVoid(instruction);
 
+#if !UNITY_2023_1_OR_NEWER
         public static SimpleCoroutineAwaiter<AsyncOperation> GetAwaiter(this AsyncOperation instruction)
             => GetAwaiterReturnSelf(instruction);
+#endif
 
         public static SimpleCoroutineAwaiter<Object> GetAwaiter(this ResourceRequest instruction)
         {

--- a/Utilities.Async/Packages/com.utilities.async/package.json
+++ b/Utilities.Async/Packages/com.utilities.async/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Async",
   "description": "A set of utilities to ease the use of async methods in Unity.",
   "keywords": [],
-  "version": "1.2.2",
+  "version": "1.2.3",
   "unity": "2019.4",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.async#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.async/releases",
@@ -16,7 +16,7 @@
   "url": "https://github.com/StephenHodgson",
   "dependencies": {
     "com.unity.editorcoroutines": "1.0.0",
-    "com.unity.test-framework": "1.3.3"
+    "com.unity.test-framework": "1.3.4"
   },
   "hideInEditor": true,
   "publishConfig": {


### PR DESCRIPTION
- removed AsyncOperation GetAwaiter as unity now supports it natively starting 2023.1